### PR TITLE
Fixes footer text color issue

### DIFF
--- a/parts/footer.html
+++ b/parts/footer.html
@@ -1,5 +1,5 @@
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"64px","bottom":"24px","left":"0px","right":"0px"}}},"backgroundColor":"ti-bg-inv","layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull has-ti-bg-inv-background-color has-background"
+<div class="wp-block-group alignfull has-ti-fg-alt-color has-ti-bg-inv-background-color has-text-color has-background"
      style="padding-top:64px;padding-right:0px;padding-bottom:24px;padding-left:0px">
     <!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"right":"20px","left":"20px"}}},"layout":{"type":"default"}} -->
     <div class="wp-block-group alignwide" style="padding-right:20px;padding-left:20px">


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->
The Footer text isn't visible on Light color palettes. This fixes the issue to make it look ok on both modes: Dark & Light.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
YES

### Screenshots 
<!-- if applicable -->

### Before

<img width="1703" alt="image" src="https://user-images.githubusercontent.com/4193672/233417789-f050200a-7206-4be8-8355-5bb42f682a37.png">

### After
<img width="1703" alt="image" src="https://user-images.githubusercontent.com/52494172/233609794-5c8e3999-9395-4960-b4ac-e0005da46827.png">



### Test instructions
<!-- Describe how this pull request can be tested. -->

- Install the build
- Go to palette switcher
- Scroll to Footer
- Change the color palettes
- make sure the text in Footer is white/visible all the time 

<!-- Issues that this pull request closes. -->
Closes #16 .
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->