### PR TITLE
feat: load survey via internal pages

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -3,17 +3,17 @@ name: Test PHP
 on:
   push:
     branches-ignore:
-      - 'master'
+      - "master"
 
 jobs:
   phplint:
     name: Phplint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Setup PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: "7.2"
           extensions: simplexml
       - name: Checkout source code
         uses: actions/checkout@v2
@@ -34,7 +34,7 @@ jobs:
         run: composer run lint
   phpunit:
     name: Phpunit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     services:
       mysql:
         image: mysql:5.7
@@ -47,7 +47,7 @@ jobs:
       - name: Setup PHP version
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.2'
+          php-version: "7.2"
           extensions: simplexml, mysql
           tools: phpunit-polyfills
       - name: Checkout source code

--- a/functions.php
+++ b/functions.php
@@ -71,6 +71,7 @@ function define_constants() {
 	define( 'JAXON_DEBUG', defined( 'WP_DEBUG' ) && WP_DEBUG === true );
 	define( 'JAXON_DIR', trailingslashit( get_template_directory() ) );
 	define( 'JAXON_URL', trailingslashit( get_template_directory_uri() ) );
+	define( 'JAXON_PRODUCT_SLUG', basename( JAXON_DIR ) );
 }
 
 /**

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -33,7 +33,7 @@ class Admin {
 		add_action( 'admin_notices', array( $this, 'render_welcome_notice' ), 0 );
 		add_action( 'wp_ajax_jaxon_dismiss_welcome_notice', array( $this, 'remove_welcome_notice' ) );
 		add_action( 'wp_ajax_jaxon_set_otter_ref', array( $this, 'set_otter_ref' ) );
-		add_action( 'admin_print_scripts', array( $this, 'add_nps_form' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'register_internal_page' ) );
 
 		add_action( 'enqueue_block_editor_assets', array( $this, 'add_fse_design_pack_notice' ) );
 		add_action( 'wp_ajax_jaxon_dismiss_design_pack_notice', array( $this, 'remove_design_pack_notice' ) );
@@ -307,27 +307,37 @@ class Admin {
 	}
 
 	/**
-	 * Add NPS form.
+	 * Register internal pages.
 	 *
 	 * @return void
 	 */
-	public function add_nps_form() {
+	public function register_internal_page() {
 		$screen = get_current_screen();
-
-		if ( current_user_can( 'manage_options' ) && ( 'dashboard' === $screen->id || 'themes' === $screen->id ) ) {
-			$website_url = preg_replace( '/[^a-zA-Z0-9]+/', '', get_site_url() );
-
-			$config = array(
-				'environmentId' => 'clr7jjqypey8v8up0bg5lk2nw',
-				'apiHost'       => 'https://app.formbricks.com',
-				'userId'        => 'jaxon_' . $website_url,
-				'attributes'    => array(
-					'days_since_install' => self::convert_to_category( round( ( time() - get_option( 'jaxon_install', time() ) ) / DAY_IN_SECONDS ) ),
-				),
-			);
-
-			echo '<script type="text/javascript">!function(){var t=document.createElement("script");t.type="text/javascript",t.async=!0,t.src="https://unpkg.com/@formbricks/js@^1.6.5/dist/index.umd.js";var e=document.getElementsByTagName("script")[0];e.parentNode.insertBefore(t,e),setTimeout(function(){window.formbricks.init(' . wp_json_encode( $config ) . ')},500)}();</script>';
+		
+		if ( ! current_user_can( 'manage_options' ) || ( 'dashboard' !== $screen->id && 'themes' !== $screen->id ) ) {
+			return;
 		}
+		
+		add_filter(
+			'themeisle-sdk/survey/' . JAXON_PRODUCT_SLUG,
+			function( $data, $page_slug ) {
+				$install_days_number = intval( ( time() - get_option( 'jaxon_install', time() ) ) / DAY_IN_SECONDS );
+
+				$data = array(
+					'environmentId' => 'clr7jjqypey8v8up0bg5lk2nw',
+					'attributes'    => array(
+						'days_since_install'  => self::convert_to_category( $install_days_number ),
+						'install_days_number' => $install_days_number,
+						'version'             => JAXON_VERSION,
+					),
+				);
+
+				return $data;
+			},
+			10,
+			2 
+		);
+		do_action( 'themeisle_internal_page', JAXON_PRODUCT_SLUG, $screen->id );
 	}
 
 	/**

--- a/inc/Admin.php
+++ b/inc/Admin.php
@@ -326,7 +326,6 @@ class Admin {
 				$data = array(
 					'environmentId' => 'clr7jjqypey8v8up0bg5lk2nw',
 					'attributes'    => array(
-						'days_since_install'  => self::convert_to_category( $install_days_number ),
 						'install_days_number' => $install_days_number,
 						'version'             => JAXON_VERSION,
 					),
@@ -338,29 +337,5 @@ class Admin {
 			2 
 		);
 		do_action( 'themeisle_internal_page', JAXON_PRODUCT_SLUG, $screen->id );
-	}
-
-	/**
-	 * Convert a number to a category.
-	 *
-	 * @param int $number Number to convert.
-	 * @param int $scale  Scale.
-	 *
-	 * @return int
-	 */
-	public static function convert_to_category( $number, $scale = 1 ) {
-		$normalized_number = intval( round( $number / $scale ) );
-
-		if ( 0 === $normalized_number || 1 === $normalized_number ) {
-			return 0;
-		} elseif ( $normalized_number > 1 && $normalized_number < 8 ) {
-			return 7;
-		} elseif ( $normalized_number >= 8 && $normalized_number < 31 ) {
-			return 30;
-		} elseif ( $normalized_number > 30 && $normalized_number < 90 ) {
-			return 90;
-		} elseif ( $normalized_number > 90 ) {
-			return 91;
-		}
 	}
 }


### PR DESCRIPTION
### Summary
<!-- Please describe the changes you made. -->

- Add internal pages hooks
- Load survey via internal pages.

### Will affect visual aspect of the product
<!-- It includes visual changes? -->
NO

### Screenshots 
<!-- if applicable -->

Use https://github.com/Codeinwp/themeisle-sdk-main/pull/287 with URL `/wp-admin/themes.php?formbricksDebug=true` and open the Browser Console

![CleanShot 2025-02-14 at 15 39 05@2x](https://github.com/user-attachments/assets/6fdbee33-fbda-43cb-8018-bb5d2ee6b4be)


### Test instructions
<!-- Describe how this pull request can be tested. -->

Use https://github.com/Codeinwp/themeisle-sdk-main/pull/287 with URL `/wp-admin/options-general.php?page=wp-cloudflare-super-page-cache-index&formbricksDebug=true` and open the Browser Console

<!-- Issues that this pull request closes. -->
Closes https://github.com/Codeinwp/themeisle/issues/1687
<!-- Should look like this: `Closes #1, closes #2, closes #3.` . -->